### PR TITLE
Small fixes and make the project compile with ocaml 5.1

### DIFF
--- a/dowsing.opam
+++ b/dowsing.opam
@@ -12,12 +12,15 @@ depends: [
   "dune" {>= "3.0"}
   "fmt"
   "containers"
+  "containers-data"
   "iter"
   "diet"
   "ocp-index"
   "ocamlgraph"
   "bos"
   "zarith"
+  "atomic"
+  "ppx_deriving"
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -16,4 +16,4 @@
 (package
  (name dowsing)
  (synopsis "Dowsing is a type of divination employed in attempts to locate functions by giving a type")
- (depends ocaml dune fmt containers iter diet ocp-index ocamlgraph bos zarith))
+ (depends ocaml dune fmt containers containers-data iter diet ocp-index ocamlgraph bos zarith atomic ppx_deriving))

--- a/lib/common/Type.ml
+++ b/lib/common/Type.ml
@@ -312,7 +312,7 @@ let of_outcometree of_outcometree env var (out_ty : Outcometree.out_type) =
   | Otyp_tuple elts ->
       elts |> Iter.of_list |> Iter.map of_outcometree |> NSet.of_iter
       |> tuple env
-  | Otyp_alias (out_ty, _) -> of_outcometree out_ty
+  | Otyp_alias {aliased; _} -> of_outcometree aliased
   (* not handled *)
   | Otyp_object _ | Otyp_class _ | Otyp_variant _ | Otyp_module _
   | Otyp_attribute _
@@ -361,7 +361,8 @@ let rec parse_to_outcome (parse_ty : Parsetree.core_type) =
       Outcometree.Otyp_arrow (str, parse_to_outcome param, parse_to_outcome ret)
   | Ptyp_tuple elts -> Outcometree.Otyp_tuple (CCList.map parse_to_outcome elts)
   | Ptyp_alias (parse_ty, str) ->
-      Outcometree.Otyp_alias (parse_to_outcome parse_ty, str)
+      Outcometree.Otyp_alias {non_gen = false; aliased = parse_to_outcome parse_ty;
+                              alias = str}
   | Ptyp_poly (s, parse_ty) ->
       let f (str : string Location.loc) = str.txt in
       let str = CCList.map f s in

--- a/lib/unification/Bitv.ml
+++ b/lib/unification/Bitv.ml
@@ -34,7 +34,7 @@ module Int : S with type t = private int = struct
 
   let is_empty n = (n = 0)
   let is_singleton n = n land (n-1) = 0
-  let is_subset i b = (i && b) <> 0
+  let is_subset i b = (i && b) = i
   let mem i b = is_subset (singleton i) b
 
   let pp = CCInt.pp_binary
@@ -57,7 +57,7 @@ module Z : S with type t = private Z.t = struct
 
   let is_empty n = Z.(n = zero)
   let is_singleton n = Z.(n land (n-one) = zero)
-  let is_subset i b = Z.((i && b) <> zero)
+  let is_subset i b = Z.((i && b) = i)
   let mem i b = is_subset (singleton i) b
 
   let pp = Z.pp_print


### PR DESCRIPTION
This is a collection of small fixes that I have found so far.
 - add the dependency to the project to be able to opam install it
 -  correct the compilation with ocaml 5.1 because of change in the compiler libs
 -  correct the implementation of subset in the bitvector implementation