### PR TITLE
Fix non proper equations

### DIFF
--- a/lib/unification/Syntactic.ml
+++ b/lib/unification/Syntactic.ml
@@ -212,23 +212,24 @@ and quasi_solved env stack x non_arrow s =
 
 (* Non proper equations
    'x ≡ 'y
+   To include a non propre equations, we need to be sure that the dependency created between variable is a DAG. Therefore, we use the Variable.compare, to order the dependency.
 *)
 and non_proper env stack (x : Variable.t) non_arrow_x (y : Variable.t) non_arrow_y =
   Trace.with_span ~__FUNCTION__ ~__LINE__ ~__FILE__ __FUNCTION__ (fun _sp ->
   match
     (Env.representative ~non_arrow:non_arrow_x env x,
      Env.representative ~non_arrow:non_arrow_y env y) with
-  | (V x' | NAR x'), (V y' | NAR y') when Variable.equal x' y' -> process_stack env stack
+  | (V x' | NAR x' | E (x', _)), (V y' | NAR y' | E (y', _)) when Variable.equal x' y' -> process_stack env stack
   | NAR y', V x' | V x', NAR y' ->
       let ty' = Type.non_arrow_var (Env.tyenv env) y' in
       let* () = attach true env x' ty' in
       process_stack env stack
   | NAR x', NAR y' ->
       if Variable.compare x' y' <= 0 then
-        let* () = attach false env y' (Type.non_arrow_var (Env.tyenv env) x') in
+        let* () = attach true env y' (Type.non_arrow_var (Env.tyenv env) x') in
         process_stack env stack
       else
-        let* () = attach false env x' (Type.non_arrow_var (Env.tyenv env) y') in
+        let* () = attach true env x' (Type.non_arrow_var (Env.tyenv env) y') in
         process_stack env stack
   | V x', V y' ->
       if Variable.compare x' y' <= 0 then
@@ -243,7 +244,6 @@ and non_proper env stack (x : Variable.t) non_arrow_x (y : Variable.t) non_arrow
   | NAR x', E (_, t) | E (_, t), NAR x' ->
       let* () = attach true env x' t in
       process_stack env stack
-  (* TODO: I don't understand why we need an order on the equality *)
   | E (x', s), E (y', t) ->
       if Variable.compare x' y' <= 0 then
         let* () = attach false env y' (Type.var (Env.tyenv env) x') in

--- a/lib/unification/Syntactic.ml
+++ b/lib/unification/Syntactic.ml
@@ -219,6 +219,7 @@ and non_proper env stack (x : Variable.t) non_arrow_x (y : Variable.t) non_arrow
   match
     (Env.representative ~non_arrow:non_arrow_x env x,
      Env.representative ~non_arrow:non_arrow_y env y) with
+  | V x', NAR y' | NAR y', V x' when Variable.equal x' y' -> failwith "A variable cannot be V and NAR at the same time."
   | (V x' | NAR x' | E (x', _)), (V y' | NAR y' | E (y', _)) when Variable.equal x' y' -> process_stack env stack
   | NAR y', V x' | V x', NAR y' ->
       let ty' = Type.non_arrow_var (Env.tyenv env) y' in

--- a/test/unit_tests/test_unification.ml
+++ b/test/unit_tests/test_unification.ml
@@ -55,11 +55,13 @@ let pos_tests = [
   "int list * int -> 'a", "int list * int -> 'a";
   (* sub constructor *)
   "int list -> 'a", "int list -> int";
-  (* Tuples target of variable: TODO I think this is a case where a variable will point to a tuples *)
+  (* Tuples target of variable *)
   "'a * 'b -> 'a", "int * unit * float -> int * unit";
   (* Loop *)
   "'a -> 'a", "'b -> 'b";
   "'a -> 'a -> 'a", "'x * b -> 'x" ;
+  (* Bug with non-proper equations *)
+  "('b, 'a, 'a, int, 'a, 'b) t", "('b, 'a, int, 'a, 'b, 'a) t";
 ]
 
 let neg_tests = [
@@ -119,5 +121,5 @@ let () = add_tests "Acic.unifiable" tests
 let () = Alcotest.run
     ~quick_only:false (* Change for slow tests *)
     ~argv:Sys.argv
-    "unification"
+    "Unifiable"
     !all_tests

--- a/test/unit_tests/test_unifier.ml
+++ b/test/unit_tests/test_unifier.ml
@@ -119,5 +119,5 @@ let () = add_tests "Acic.unifier" tests
 let () = Alcotest.run
     ~quick_only:false (* Change for slow tests *)
     ~argv:Sys.argv
-    "unification"
+    "Unifier"
     !all_tests


### PR DESCRIPTION
In the case of a non-proper equation `x = y` such that both variables have the same value `t`. Then, if we introduce the equation `x = y` and `y = x`, this creates a loop and gets rejected by the occur_check. The problem here is that the order of `x` and `y` is defined with respect to the value associated to it. This commit changes that to compare directly the variables. This change guaranty that the non-proper equation will form a DAG and prevent any cycle. As a side effect, this makes the comparison faster.